### PR TITLE
BugFix: TOC LI Indent cahnged to 4 spaces!

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ gfmtoc.getEOL = function (s) {
 
 gfmtoc.buildTOC = function (markdown, eol) {
   var h = [];
-  var indent = "  ";
+  var indent = "    ";
   var renderer = new marked.Renderer();
 
   if (!eol) {


### PR DESCRIPTION
Fixes bug pointed out in: https://github.com/hail2u/node-gfmtoc/issues/1

The original 2-space indent caused markdown linters, formatters and
converters to "skip" an header level — H1 and H2 would bothe be seen as
H1: H3 and H4 as H2; ecc.

Standard markdown indenting for sub-list elements should be 4 spaces:

> To nest one list within another, indent each item
> in the sublist by four spaces.
> http://commonmark.org/help/tutorial/10-nestedLists.html

After testing this fix with various MD tools (including Pandoc) I've
confirmed that 4-spaces indent fixes the issue.
